### PR TITLE
install_libspotify: Error out if any step fails

### DIFF
--- a/install_libspotify.sh
+++ b/install_libspotify.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 wget https://developer.spotify.com/download/libspotify/libspotify-12.1.51-Linux-x86_64-release.tar.gz
 tar -xvf libspotify-12.1.51-Linux-x86_64-release.tar.gz
 cd libspotify-12.1.51-Linux-x86_64-release && patch < ../libspotify-Makefile.patch && make prefix=$HOME/libspotify install


### PR DESCRIPTION
install_libspotify.sh is run by travis.ci in the before_script section.
According to travis' documentation[1]:

```
If before_install, install or before_script return a non-zero
exit code, the build is errored and stops immediately.
```

Inexpensive safeguards are always nice to have, especially when they
support the 'crash early' mantra.

1: https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build

Signed-off-by: Carl Helmertz helmertz@gmail.com
