### PR TITLE
Correctly escape ampersands in xspf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ missing
 stamp-h1
 test-driver
 install-sh
+
+config.guess
+config.sub
+libtool
+ltmain.sh
+m4/
+test-suite.log
+tests_*

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,14 +26,18 @@ spotifile_SOURCES = src/spfs_fuse.c src/spfs_fuse.h \
 tests_spfs_fuse_test_SOURCES = tests/spfs_fuse_test.c \
 							   src/spfs_fuse_utils.c src/spfs_fuse_utils.h \
 							   src/spfs_fuse_entity.c src/spfs_fuse_entity.h \
-							   src/spfs_path.c src/spfs_path.h
+							   src/spfs_path.c src/spfs_path.h \
+							   src/string_utils.c src/string_utils.h
 tests_spfs_fuse_test_LDADD = $(CHECK_LIBS) $(GLIB_LIBS)
 
 tests_spfs_fuse_utils_test_SOURCES = tests/spfs_fuse_utils_test.c \
-									 src/spfs_fuse_utils.c src/spfs_fuse_utils.h
+									 src/spfs_fuse_utils.c src/spfs_fuse_utils.h \
+									 src/string_utils.c src/string_utils.h
 tests_spfs_fuse_utils_test_LDADD = $(CHECK_LIBS) $(GLIB_LIBS)
 
 
 tests_xspf_test_SOURCES = tests/xspf_test.c \
-									 src/xspf.c src/xspf.h
+									 src/xspf.c src/xspf.h \
+									 src/string_utils.c src/string_utils.h \
+									 src/xspf_sanitize.c src/xspf_sanitize.h
 tests_xspf_test_LDADD = $(CHECK_LIBS) $(GLIB_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,9 @@ spotifile_SOURCES = src/spfs_fuse.c src/spfs_fuse.h \
 					src/spfs_audio.c src/spfs_audio.h \
 					src/xspf.c src/xspf.h \
 					src/spotify-fs.c src/spotify-fs.h \
-					src/spfs_appkey.c src/spfs_appkey.h
+					src/spfs_appkey.c src/spfs_appkey.h \
+                    src/string_utils.c src/string_utils.h \
+                    src/xspf_sanitize.c src/xspf_sanitize.h
 
 tests_spfs_fuse_test_SOURCES = tests/spfs_fuse_test.c \
 							   src/spfs_fuse_utils.c src/spfs_fuse_utils.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS += -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-fu
 AM_CPPFLAGS += -I$(top_srcdir)/src -D_GNU_SOURCE=1 -DSPOTIFILE_VERSION=\"@PACKAGE_VERSION@\"
 bin_PROGRAMS = spotifile
 dist_sbin_SCRIPTS = src/scripts/mount.spotifile
-check_PROGRAMS = tests_spfs_fuse_test tests_spfs_fuse_utils_test tests_xspf_test
+check_PROGRAMS = tests_spfs_fuse_test tests_spfs_fuse_utils_test tests_sanitize_test tests_xspf_test
 TESTS = $(check_PROGRAMS)
 spotifile_LDADD = $(SPOTIFY_LIBS) $(GLIB_LIBS) $(FUSE_LIBS)
 spotifile_SOURCES = src/spfs_fuse.c src/spfs_fuse.h \
@@ -41,3 +41,8 @@ tests_xspf_test_SOURCES = tests/xspf_test.c \
 									 src/string_utils.c src/string_utils.h \
 									 src/xspf_sanitize.c src/xspf_sanitize.h
 tests_xspf_test_LDADD = $(CHECK_LIBS) $(GLIB_LIBS)
+
+tests_sanitize_test_SOURCES = tests/sanitize_test.c \
+									 src/string_utils.c src/string_utils.h \
+									 src/xspf_sanitize.c src/xspf_sanitize.h
+tests_sanitize_test_LDADD = $(CHECK_LIBS) $(GLIB_LIBS)

--- a/src/spfs_fuse_utils.c
+++ b/src/spfs_fuse_utils.c
@@ -1,5 +1,4 @@
 #include <string.h>
-#include <sys/types.h>
 #include "spfs_fuse_utils.h"
 #include "string_utils.h"
 

--- a/src/spfs_fuse_utils.c
+++ b/src/spfs_fuse_utils.c
@@ -1,24 +1,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include "spfs_fuse_utils.h"
-static gchar *str_replace(const gchar *s, const gchar *c, const gchar *replacement) {
-	size_t s_l = strlen(s);
-	size_t r_l = strlen(replacement);
-	size_t c_l = strlen(c);
-	gchar *new = g_malloc0(s_l + r_l + 1);
-	gchar *p = strstr(s, c);
-	if (!p) {
-		strcpy(new, s);
-		return new;
-	}
-
-	off_t off = p - s;
-	memcpy(new, s, off);
-	memcpy(new + off, replacement, r_l);
-	memcpy(new + off + r_l, s + off + c_l, s_l - c_l - off);
-	new[s_l + r_l] = '\0';
-	return new;
-}
+#include "string_utils.h"
 
 gchar * spfs_replace_slashes(const gchar *s, const gchar *replacement) {
 	g_return_val_if_fail(s != NULL, NULL);

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -1,5 +1,6 @@
 #include "string_utils.h"
 #include <string.h>
+#include <sys/types.h>
 
 gchar *str_replace(const gchar *s, const gchar *c, const gchar *replacement) {
 	size_t s_l = strlen(s);

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -1,0 +1,21 @@
+#include "string_utils.h"
+#include <string.h>
+
+gchar *str_replace(const gchar *s, const gchar *c, const gchar *replacement) {
+	size_t s_l = strlen(s);
+	size_t r_l = strlen(replacement);
+	size_t c_l = strlen(c);
+	gchar *new = g_malloc0(s_l + r_l + 1);
+	gchar *p = strstr(s, c);
+	if (!p) {
+		strcpy(new, s);
+		return new;
+	}
+
+	off_t off = p - s;
+	memcpy(new, s, off);
+	memcpy(new + off, replacement, r_l);
+	memcpy(new + off + r_l, s + off + c_l, s_l - c_l - off);
+	new[s_l + r_l] = '\0';
+	return new;
+}

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -1,0 +1,5 @@
+#ifndef STRING_UTILS_H
+#define STRING_UTILS_H
+#include <glib.h>
+gchar *str_replace(const gchar *s, const gchar *c, const gchar *replacement);
+#endif /* STRING_UTILS_H */

--- a/src/xspf.c
+++ b/src/xspf.c
@@ -92,18 +92,18 @@ xspf * xspf_track_set_duration(xspf *x, int duration) {
 }
 xspf * xspf_track_set_title(xspf *x, const gchar *title) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<title>%s</title>\n", xspf_escape_amperstand(title));
+	g_string_append_printf(x->string, "<title>%s</title>\n", xspf_escape_ampersand(title));
 	return x;
 }
 
 xspf * xspf_track_set_creator(xspf *x, const gchar *creator) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<creator>%s</creator>\n", xspf_escape_amperstand(creator));
+	g_string_append_printf(x->string, "<creator>%s</creator>\n", xspf_escape_ampersand(creator));
 	return x;
 }
 
 xspf * xspf_track_set_album(xspf *x, const gchar *album) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<album>%s</album>\n", xspf_escape_amperstand(album));
+	g_string_append_printf(x->string, "<album>%s</album>\n", xspf_escape_ampersand(album));
 	return x;
 }

--- a/src/xspf.c
+++ b/src/xspf.c
@@ -98,12 +98,12 @@ xspf * xspf_track_set_title(xspf *x, const gchar *title) {
 
 xspf * xspf_track_set_creator(xspf *x, const gchar *creator) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<creator>%s</creator>\n", creator);
+	g_string_append_printf(x->string, "<creator>%s</creator>\n", xspf_escape_amperstand(creator));
 	return x;
 }
 
 xspf * xspf_track_set_album(xspf *x, const gchar *album) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<album>%s</album>\n", album);
+	g_string_append_printf(x->string, "<album>%s</album>\n", xspf_escape_amperstand(album));
 	return x;
 }

--- a/src/xspf.c
+++ b/src/xspf.c
@@ -1,4 +1,5 @@
 #include <xspf.h>
+#include "xspf_sanitize.h"
 
 enum XSPFState {
 	INIT,
@@ -91,7 +92,7 @@ xspf * xspf_track_set_duration(xspf *x, int duration) {
 }
 xspf * xspf_track_set_title(xspf *x, const gchar *title) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<title>%s</title>\n", title);
+	g_string_append_printf(x->string, "<title>%s</title>\n", xspf_escape_amperstand(title));
 	return x;
 }
 

--- a/src/xspf.c
+++ b/src/xspf.c
@@ -92,18 +92,18 @@ xspf * xspf_track_set_duration(xspf *x, int duration) {
 }
 xspf * xspf_track_set_title(xspf *x, const gchar *title) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<title>%s</title>\n", xspf_escape_ampersand(title));
+	g_string_append_printf(x->string, "<title>%s</title>\n", xspf_sanitize(title));
 	return x;
 }
 
 xspf * xspf_track_set_creator(xspf *x, const gchar *creator) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<creator>%s</creator>\n", xspf_escape_ampersand(creator));
+	g_string_append_printf(x->string, "<creator>%s</creator>\n", xspf_sanitize(creator));
 	return x;
 }
 
 xspf * xspf_track_set_album(xspf *x, const gchar *album) {
 	g_warn_if_fail(x->state == TRACK_BEGIN);
-	g_string_append_printf(x->string, "<album>%s</album>\n", xspf_escape_ampersand(album));
+	g_string_append_printf(x->string, "<album>%s</album>\n", xspf_sanitize(album));
 	return x;
 }

--- a/src/xspf_sanitize.c
+++ b/src/xspf_sanitize.c
@@ -14,7 +14,7 @@ const gchar * replace_all(const gchar * str, const gchar *key, const gchar * val
     return tmpstr;
 }
 
-gchar * xspf_escape_amperstand(const gchar * s) {
+gchar * xspf_escape_ampersand(const gchar * s) {
     gchar * tmpstr = str_replace(s, "&", "!amp;");
     replace_all(tmpstr, "!amp;", "&amp;");
     return tmpstr;

--- a/src/xspf_sanitize.c
+++ b/src/xspf_sanitize.c
@@ -1,7 +1,7 @@
 #include <string.h>
+#include <stdio.h>
 #include "xspf_sanitize.h"
 #include "string_utils.h"
-#include <stdio.h>
 
 gchar * replace_all(const gchar * str, const gchar *key, const gchar * val) {
     gchar * tmpstr = str_replace(str, key, val);

--- a/src/xspf_sanitize.c
+++ b/src/xspf_sanitize.c
@@ -3,7 +3,7 @@
 #include "string_utils.h"
 #include <stdio.h>
 
-const gchar * replace_all(const gchar * str, const gchar *key, const gchar * val) {
+gchar * replace_all(const gchar * str, const gchar *key, const gchar * val) {
     gchar * tmpstr = str_replace(str, key, val);
     while (strstr(tmpstr, key) != NULL) {
         gchar *old = tmpstr;
@@ -14,8 +14,51 @@ const gchar * replace_all(const gchar * str, const gchar *key, const gchar * val
     return tmpstr;
 }
 
+// be sure to esacpe whatever needs to be escaped in XML format
+// " ->  &quot;
+// ' ->  &apos;
+// < ->  &lt;
+// > -> &gt;
+// & -> &amp;
+
+gchar * xspf_escape_double_quote(const gchar * s) {
+    return replace_all(s, "\"", "&quot;");
+}
+
+gchar * xspf_escape_single_quote(const gchar * s) {
+    return replace_all(s, "\'", "&apos;");
+}
+
+gchar * xspf_escape_lt(const gchar * s) {
+    return replace_all(s, "<", "&lt;");
+}
+
+gchar * xspf_escape_gt(const gchar * s) {
+    return replace_all(s, ">", "&gt;");
+}
+
 gchar * xspf_escape_ampersand(const gchar * s) {
     gchar * tmpstr = str_replace(s, "&", "!amp;");
-    replace_all(tmpstr, "!amp;", "&amp;");
-    return tmpstr;
+    return replace_all(tmpstr, "!amp;", "&amp;");
+}
+
+gchar * xspf_sanitize(const gchar * s) {
+    gchar * tmp = xspf_escape_ampersand(s);
+    if(strstr(tmp, "\"") != NULL) {
+        tmp = xspf_escape_double_quote(tmp);
+    }
+
+    if(strstr(tmp, "\'") != NULL) {
+        tmp = xspf_escape_single_quote(tmp);
+    }
+
+    if(strstr(tmp, "<") != NULL) {
+        tmp = xspf_escape_lt(tmp);
+    }
+
+    if (strstr(tmp, ">") != NULL) {
+        tmp = xspf_escape_gt(tmp);
+    }
+
+    return tmp;
 }

--- a/src/xspf_sanitize.c
+++ b/src/xspf_sanitize.c
@@ -1,0 +1,21 @@
+#include <string.h>
+#include "xspf_sanitize.h"
+#include "string_utils.h"
+#include <stdio.h>
+
+const gchar * replace_all(const gchar * str, const gchar *key, const gchar * val) {
+    gchar * tmpstr = str_replace(str, key, val);
+    while (strstr(tmpstr, key) != NULL) {
+        gchar *old = tmpstr;
+        tmpstr = str_replace(tmpstr, key, val);
+        g_free(old);
+    }
+
+    return tmpstr;
+}
+
+gchar * xspf_escape_amperstand(const gchar * s) {
+    gchar * tmpstr = str_replace(s, "&", "!amp;");
+    replace_all(tmpstr, "!amp;", "&amp;");
+    return tmpstr;
+}

--- a/src/xspf_sanitize.h
+++ b/src/xspf_sanitize.h
@@ -1,5 +1,5 @@
 #ifndef XSPF_SANITIZE_H
 #define XSPF_SANITIZE_H
 #include <glib.h>
-gchar * xspf_escape_amperstand(const gchar * s);
+gchar * xspf_escape_ampersand(const gchar * s);
 #endif /* XSPF_SANITIZE_H */

--- a/src/xspf_sanitize.h
+++ b/src/xspf_sanitize.h
@@ -1,0 +1,5 @@
+#ifndef XSPF_SANITIZE_H
+#define XSPF_SANITIZE_H
+#include <glib.h>
+gchar * xspf_escape_amperstand(const gchar * s);
+#endif /* XSPF_SANITIZE_H */

--- a/src/xspf_sanitize.h
+++ b/src/xspf_sanitize.h
@@ -1,5 +1,5 @@
 #ifndef XSPF_SANITIZE_H
 #define XSPF_SANITIZE_H
 #include <glib.h>
-gchar * xspf_escape_ampersand(const gchar * s);
+gchar * xspf_sanitize(const gchar *s );
 #endif /* XSPF_SANITIZE_H */

--- a/tests/sanitize_test.c
+++ b/tests/sanitize_test.c
@@ -1,0 +1,43 @@
+#include <check.h>
+#include <stdlib.h>
+#include "xspf_sanitize.h"
+
+START_TEST(xspf_sanitization)
+{
+  // Sanitization happends only on the final string containint song/album/artist name.
+  const char * source_str = "ampersand: & - single quote: \' - double quote: \" - greater than: > - less than: <";
+  const char * dest_str = "ampersand: &amp; - single quote: &apos; - double quote: &quot; - greater than: &gt; - less than: &lt;";
+  ck_assert_str_eq(xspf_sanitize(source_str), dest_str);
+}
+END_TEST
+
+Suite * sanitization_test(void)
+{
+    Suite *s;
+    TCase *tc_core;
+
+    s = suite_create("XSPF Sanitization");
+
+    /* Core test case */
+    tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, xspf_sanitization);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+ int main(void)
+ {
+    int number_failed;
+    Suite *s;
+    SRunner *sr;
+
+    s = sanitization_test();
+    sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+ }


### PR DESCRIPTION
As the title says :)

My C is not really good nowadays so feel free to make any correction or simply reject this PR.

This PR correctly escapes "&" with "&amp;": I've tested with my "Discover Weekly" which this week contains a track with an "&", without this patch, the playlist file is considered as malformed and not all the tracks are being recognized by the player's parser.

Also my english is not that good, so please forgive me for any error :)
